### PR TITLE
Fix linux build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/glfw"]
+	path = deps/glfw
+	url = https://github.com/glfw/glfw

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "files.associations": {
+        "bit": "c",
+        "*.tcc": "c",
+        "chrono": "c",
+        "functional": "c",
+        "string_view": "c",
+        "random": "c",
+        "istream": "c",
+        "limits": "c",
+        "numeric": "c",
+        "semaphore": "c",
+        "valarray": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "limits": "c",
         "numeric": "c",
         "semaphore": "c",
-        "valarray": "c"
+        "valarray": "c",
+        "noise1234.h": "c"
     }
 }

--- a/src/mvmath.c
+++ b/src/mvmath.c
@@ -227,3 +227,7 @@ void v3_lerp(vec3* v, vec3 *a, vec3 *b, float t) {
     v->y = lerp(a->y, b->y, t);
     v->z = lerp(a->z, b->z, t);
 }
+
+int max(int a, int b) {
+    return (a > b ? a : b);
+}

--- a/src/mvmath.h
+++ b/src/mvmath.h
@@ -78,4 +78,6 @@ void ortho(mat4 *m, float left, float right, float bottom, float top, float near
 float lerp(float a, float b, float t);
 void v3_lerp(vec3 *v, vec3 *a, vec3 *b, float t);
 
+int max(int a, int b);
+
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -92,3 +92,8 @@ void load_png_texture(const char *file_name)
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
     free(data);
 }
+
+// Fixing a weird error
+int max(int n1, int n2) {
+    return (n1 > n2 ? n1 : n2);
+}

--- a/src/util.c
+++ b/src/util.c
@@ -92,8 +92,3 @@ void load_png_texture(const char *file_name)
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei) width, (GLsizei) height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
     free(data);
 }
-
-// Fixes a linker error
-int max(int n1, int n2) {
-    return (n1 > n2 ? n1 : n2);
-}

--- a/src/util.c
+++ b/src/util.c
@@ -93,7 +93,7 @@ void load_png_texture(const char *file_name)
     free(data);
 }
 
-// Fixing a weird error
+// Fixes a linker error
 int max(int n1, int n2) {
     return (n1 > n2 ? n1 : n2);
 }

--- a/src/worldgen.c
+++ b/src/worldgen.c
@@ -1,5 +1,6 @@
 #include "worldgen.h"
 #include "noise.h"
+#include "mvmath.h"
 
 enum Biome
 {


### PR DESCRIPTION
This PR adds `deps/glfw` as a submodule (previously, it thought it was, but it somehow actually wasn't) and adds a `max` function to `util.c`, since the lack thereof was generating a linker error.

It looks like VSCode also sneaked a settings file in; I can remove that if you'd like.