### PR TITLE
fix: Add headers to compile on macOS.

### DIFF
--- a/src/noise.c
+++ b/src/noise.c
@@ -1,4 +1,5 @@
 #include "noise.h"
+#include "string.h"
 
 
 f32 octave_compute(struct Octave *p, f32 seed, f32 x, f32 z) {

--- a/src/noise.h
+++ b/src/noise.h
@@ -5,6 +5,7 @@
 #include "chunk.h"
 
 #include <noise1234.h>
+#include <stdlib.h>
 
 typedef uint8_t u8;
 typedef uint16_t u16;


### PR DESCRIPTION
Didn't have headers for memcpy() and rand() on macOS. Adding them shouldn't affect compilation on other platforms.